### PR TITLE
no longer exports ELB cert arn as it was unneeded

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,7 +8,8 @@ phases:
       - curl --silent --location https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz | tar xz -C .
       - chmod +x ./kubectl ./aws-iam-authenticator
       - export PATH=$PWD/:$PATH
-      - apt-get update && apt-get -y install jq python3-pip python3-dev && pip3 install --upgrade awscli
+      - apt-get update && apt-get -y install jq
+      - curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install
   pre_build:
       commands:
         - export KUBECONFIG=$HOME/.kube/config

--- a/resources/templates/eks-ref-base.yaml
+++ b/resources/templates/eks-ref-base.yaml
@@ -35,12 +35,6 @@ Resources:
       Region: us-east-1
       CfnParameters:
         CustomDomainName: !Ref CustomDomainName
-  # DomainHostedZone:
-  #   Type: 'AWS::Route53::HostedZone'
-  #   Properties: 
-  #     HostedZoneConfig: 
-  #       Comment: 'Hosted zone for custom domain'
-  #     Name: !Ref CustomDomainName
   CloudFrontOriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
     Properties:
@@ -64,10 +58,6 @@ Outputs:
     Value: !GetAtt CloudFormationAppCert.CloudFrontAppCert
     Export:
       Name: !Sub '${AWS::StackName}-CloudFrontAppCertArn'
-  ELBAppCertArn:
-    Value: !Ref ELBCertificate
-    Export:
-      Name: !Sub '${AWS::StackName}-ELBCertificate'
   S3OAIUserId:
     Value: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
     Export:


### PR DESCRIPTION
*Description of changes:* Deleted the ELB Arn export. It wasn't used anywhere downstream, and if this stack was created in us-east-1, the ELB would be conditionally NOT created causes the deployment to fail when trying to export it.
