### PR TITLE
CloudFront regional domains

### DIFF
--- a/resources/templates/eks-ref-site-admin.yaml
+++ b/resources/templates/eks-ref-site-admin.yaml
@@ -69,7 +69,7 @@ Resources:
         Enabled: true
         HttpVersion: http2
         Origins:
-        - DomainName: !GetAtt AdminAppBucket.DomainName
+        - DomainName: !GetAtt AdminAppBucket.RegionalDomainName
           Id: s3origin
           S3OriginConfig:
             OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${S3OAIId}

--- a/resources/templates/eks-ref-site-application.yaml
+++ b/resources/templates/eks-ref-site-application.yaml
@@ -64,7 +64,7 @@ Resources:
         Enabled: true
         HttpVersion: http2
         Origins:
-        - DomainName: !GetAtt 'AppBucket.DomainName'
+        - DomainName: !GetAtt 'AppBucket.RegionalDomainName'
           Id: s3origin
           S3OriginConfig:
             OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${S3OAIId}'

--- a/resources/templates/eks-ref-site-landing.yaml
+++ b/resources/templates/eks-ref-site-landing.yaml
@@ -64,7 +64,7 @@ Resources:
         Enabled: true
         HttpVersion: http2
         Origins:
-        - DomainName: !GetAtt 'LandingAppBucket.DomainName'
+        - DomainName: !GetAtt 'LandingAppBucket.RegionalDomainName'
           Id: s3origin
           S3OriginConfig:
             OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${S3OAIId}'


### PR DESCRIPTION
adjusting cloudfront origin to be regional domain to get around DNS propagation issue. The regional domains, when used as an origin, show up almost instantaneously vs. global domains which take some time.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
