### PR TITLE
Update cluster

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   install:
     commands:
       - curl -sS -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
-      - curl -sS -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/darwin/amd64/kubectl
+      - curl -sS -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/kubectl
       - curl --silent --location https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz | tar xz -C .
       - chmod +x ./kubectl ./aws-iam-authenticator
       - export PATH=$PWD/:$PATH

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,15 +4,15 @@ phases:
   install:
     commands:
       - curl -sS -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
-      - curl -sS -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.7/2020-07-08/bin/linux/amd64/kubectl
+      - curl -sS -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/darwin/amd64/kubectl
       - curl --silent --location https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz | tar xz -C .
       - chmod +x ./kubectl ./aws-iam-authenticator
       - export PATH=$PWD/:$PATH
       - apt-get update && apt-get -y install jq
       - curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && unzip awscliv2.zip && ./aws/install
   pre_build:
-      commands:
-        - export KUBECONFIG=$HOME/.kube/config
+    commands:
+      - export KUBECONFIG=$HOME/.kube/config
   build:
     commands:
 
@@ -46,4 +46,4 @@ phases:
       - sed -i -e 's,ORDER_SERVICE_ECR_REPO_URI,'$ORDER_SERVICE_ECR_REPO_URI',g' services/application-services/order-service/kubernetes/order-service.yaml
       - kubectl apply -f services/application-services/order-service/kubernetes/order-service.yaml -n $TENANT_NAME
       - sed -i -e 's,TENANT_NAME,'$TENANT_NAME',g' resources/policy/tenant-service-policy.yaml
-      - kubectl apply -f resources/policy/tenant-service-policy.yaml -n $TENANT_NAME 
+      - kubectl apply -f resources/policy/tenant-service-policy.yaml -n $TENANT_NAME

--- a/clients/Admin/src/app/containers/default-layout/default-layout.component.ts
+++ b/clients/Admin/src/app/containers/default-layout/default-layout.component.ts
@@ -40,6 +40,6 @@ export class DefaultLayoutComponent implements OnInit {
     this.oidcSecurityService.logoffAndRevokeTokens().subscribe(() => {});
     const match = environment.issuer.match(/(?!\.)([\w-]+)(?=\.amazonaws)/);
     const region = !!match ? match[0] : '';
-    window.location.href = `https://${environment.domain}.auth.${region}.amazoncognito.com/login?client_id=${environment.clientId}&response_type=code&redirect_uri=https://admin.${environment.domain}`;
+    window.location.href = `https://${environment.customDomain}.auth.${region}.amazoncognito.com/login?client_id=${environment.clientId}&response_type=code&redirect_uri=https://admin.${environment.domain}`;
   }
 }

--- a/clients/Admin/src/environments/environment.prod.ts
+++ b/clients/Admin/src/environments/environment.prod.ts
@@ -1,7 +1,8 @@
 export const environment = {
   production: true,
-  clientId: '2j5qgn5ejbgdh06ibsj4f2d4qv',
-  issuer: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_C6nwHKeXW',
-  apiUrl: 'https://api.eks-ref-arch.com',
-  domain: 'eks-ref-arch.com'
+  clientId: '$APPCLIENTID',
+  issuer: '$AUTHSERVERURL',
+  customDomain: '$AUTHCUSTOMDOMAIN',
+  apiUrl: 'https://api.$CUSTOM_DOMAIN',
+  domain: '$CUSTOM_DOMAIN',
 };

--- a/clients/Admin/src/environments/environment.ts
+++ b/clients/Admin/src/environments/environment.ts
@@ -1,7 +1,8 @@
 export const environment = {
   production: true,
-  clientId: '2j5qgn5ejbgdh06ibsj4f2d4qv',
-  issuer: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_C6nwHKeXW',
-  apiUrl: 'https://api.eks-ref-arch.com',
-  domain: 'eks-ref-arch.com'
+  clientId: '$APPCLIENTID',
+  issuer: '$AUTHSERVERURL',
+  customDomain: '$AUTHCUSTOMDOMAIN',
+  apiUrl: 'https://api.$CUSTOM_DOMAIN',
+  domain: '$CUSTOM_DOMAIN',
 };

--- a/clients/Application/src/app/service-helper.service.ts
+++ b/clients/Application/src/app/service-helper.service.ts
@@ -14,16 +14,14 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import { NAMED_ENTITIES } from '@angular/compiler';
 import { Injectable } from '@angular/core';
 import { environment } from '../environments/environment';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ServiceHelperService {
-
-  constructor() { }
+  constructor() {}
 
   getUrl(entity: string) {
     const tenantId = this.getTenantName();
@@ -38,4 +36,3 @@ export class ServiceHelperService {
     return tenantId;
   }
 }
-

--- a/deploy-cluster.sh
+++ b/deploy-cluster.sh
@@ -19,7 +19,7 @@ kind: ClusterConfig
 metadata:
   name: eks-saas
   region: ${AWS_REGION}
-  version: "1.17"
+  version: "1.21"
 
 availabilityZones: ["${AWS_REGION}a", "${AWS_REGION}b", "${AWS_REGION}c"]
 

--- a/resources/templates/deployment-master.yaml
+++ b/resources/templates/deployment-master.yaml
@@ -13,11 +13,11 @@ spec:
         app: tenant-registration
     spec:
       containers:
-      - name: tenant-registration
-        image: TENANT_REG_ECR:latest
-        ports:
-        - containerPort: 8000
-          name: "http"
+        - name: tenant-registration
+          image: TENANT_REG_ECR:latest
+          ports:
+            - containerPort: 8000
+              name: "http"
 ---
 apiVersion: v1
 kind: Service
@@ -27,14 +27,14 @@ spec:
   selector:
     app: tenant-registration
   ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 8000
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8000
   type: NodePort
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tenant-registration-service-ingress
@@ -42,35 +42,45 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: api.DOMAIN_NAME
-    http:
-      paths:
-      - backend:
-          serviceName: tenant-registration-service
-          servicePort: 80
-        path: /
-  - host: api.DOMAIN_NAME
-    http:
-      paths:
-      - backend:
-          serviceName: tenant-management-service
-          servicePort: 80
-        path: /auth-info
-  - host: api.DOMAIN_NAME
-    http:
-      paths:
-      - backend:
-          serviceName: tenant-management-service
-          servicePort: 80
-        path: /tenants
-  - host: api.DOMAIN_NAME
-    http:
-      paths:
-      - backend:
-          serviceName: user-management-service
-          servicePort: 80
-        path: /users
-
+    - host: api.DOMAIN_NAME
+      http:
+        paths:
+          - backend:
+              service:
+                name: tenant-registration-service
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
+    - host: api.DOMAIN_NAME
+      http:
+        paths:
+          - backend:
+              service:
+                name: tenant-management-service
+                port: 80
+            path: /auth-info
+            pathType: Prefix
+    - host: api.DOMAIN_NAME
+      http:
+        paths:
+          - backend:
+              service:
+                name: tenant-management-service
+                port:
+                  number: 80
+            path: /tenants
+            pathType: Prefix
+    - host: api.DOMAIN_NAME
+      http:
+        paths:
+          - backend:
+              service:
+                name: user-management-service
+                port:
+                  number: 80
+            path: /users
+            pathType: Prefix
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -87,11 +97,11 @@ spec:
         app: tenant-management
     spec:
       containers:
-      - name: tenant-management
-        image: TENANT_MGMT_ECR:latest
-        ports:
-        - containerPort: 8002
-          name: "http"
+        - name: tenant-management
+          image: TENANT_MGMT_ECR:latest
+          ports:
+            - containerPort: 8002
+              name: "http"
 ---
 apiVersion: v1
 kind: Service
@@ -101,10 +111,10 @@ spec:
   selector:
     app: tenant-management
   ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 8002
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8002
   type: NodePort
 
 ---
@@ -123,11 +133,11 @@ spec:
         app: user-management
     spec:
       containers:
-      - name: user-management
-        image: USER_MGMT_ECR:latest
-        ports:
-        - containerPort: 8001
-          name: "http"
+        - name: user-management
+          image: USER_MGMT_ECR:latest
+          ports:
+            - containerPort: 8001
+              name: "http"
 ---
 apiVersion: v1
 kind: Service
@@ -137,8 +147,8 @@ spec:
   selector:
     app: user-management
   ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 8001
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8001
   type: NodePort

--- a/services/application-services/order-service/kubernetes/order-service.yaml
+++ b/services/application-services/order-service/kubernetes/order-service.yaml
@@ -13,11 +13,11 @@ spec:
         app: order
     spec:
       containers:
-      - name: order
-        image: ORDER_SERVICE_ECR_REPO_URI:latest
-        ports:
-        - containerPort: 5001
-          name: "http"
+        - name: order
+          image: ORDER_SERVICE_ECR_REPO_URI:latest
+          ports:
+            - containerPort: 5001
+              name: "http"
 ---
 apiVersion: v1
 kind: Service
@@ -27,14 +27,14 @@ spec:
   selector:
     app: order
   ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 5001
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 5001
   type: NodePort
-  
+
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: order-service-ingress
@@ -42,10 +42,13 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: api.CUSTOM_DOMAIN
-    http:
-      paths:
-      - path: /TENANT_NAME/order
-        backend:
-          serviceName: order-service
-          servicePort: 80
+    - host: api.CUSTOM_DOMAIN
+      http:
+        paths:
+          - path: /TENANT_NAME/order
+            backend:
+              service:
+                name: order-service
+                port:
+                  number: 80
+            pathType: Prefix

--- a/services/application-services/product-service/kubernetes/product-service.yaml
+++ b/services/application-services/product-service/kubernetes/product-service.yaml
@@ -13,11 +13,11 @@ spec:
         app: product
     spec:
       containers:
-      - name: product
-        image: PRODUCT_SERVICE_ECR_REPO_URI:latest
-        ports:
-        - containerPort: 5000
-          name: "http"
+        - name: product
+          image: PRODUCT_SERVICE_ECR_REPO_URI:latest
+          ports:
+            - containerPort: 5000
+              name: "http"
 ---
 apiVersion: v1
 kind: Service
@@ -27,14 +27,14 @@ spec:
   selector:
     app: product
   ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 5000
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 5000
   type: NodePort
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: product-service-ingress
@@ -42,10 +42,13 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: api.CUSTOM_DOMAIN
-    http:
-      paths:
-      - path: /TENANT_NAME/product
-        backend:
-          serviceName: product-service
-          servicePort: 80
+    - host: api.CUSTOM_DOMAIN
+      http:
+        paths:
+          - path: /TENANT_NAME/product
+            backend:
+              service:
+                name: product-service
+                port:
+                  number: 80
+            pathType: Prefix

--- a/services/shared-services/tenant-registration-service/kubernetes/tenant-registration-service.yaml
+++ b/services/shared-services/tenant-registration-service/kubernetes/tenant-registration-service.yaml
@@ -13,11 +13,11 @@ spec:
         app: tenant-registration
     spec:
       containers:
-      - name: tenant-registration
-        image: AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/tenant-registration-service:latest
-        ports:
-        - containerPort: 8000
-          name: "http"
+        - name: tenant-registration
+          image: AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/tenant-registration-service:latest
+          ports:
+            - containerPort: 8000
+              name: "http"
 ---
 apiVersion: v1
 kind: Service
@@ -27,14 +27,14 @@ spec:
   selector:
     app: tenant-registration
   ports:
-  - name: http
-    protocol: TCP
-    port: 80
-    targetPort: 8000
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8000
   type: NodePort
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: tenant-registration-service-ingress
@@ -42,10 +42,13 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
-  - host: api.CUSTOM_DOMAIN
-    http:
-      paths:
-      - backend:
-          serviceName: tenant-registration-service
-          servicePort: 80
-        path: /
+    - host: api.CUSTOM_DOMAIN
+      http:
+        paths:
+          - backend:
+              service:
+                name: tenant-registration-service
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Installing kubectl"
 sudo curl --silent --location -o /usr/local/bin/kubectl \
-  https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/darwin/amd64/kubectl
+  https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/kubectl
 
 sudo chmod +x /usr/local/bin/kubectl
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Installing kubectl"
 sudo curl --silent --location -o /usr/local/bin/kubectl \
-  https://amazon-eks.s3.us-west-2.amazonaws.com/1.17.7/2020-07-08/bin/linux/amd64/kubectl
+  https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/darwin/amd64/kubectl
 
 sudo chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #22 

*Description of changes:*
The link that was assembled to redirect cognito to the hosted UI page was using the wrong domain. It was using the app's domain vs. the cognito custom domain.

Also, updated the cluster version to 1.21 and corresponding `ingress` objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
