### PR TITLE
Fix: Quote environment variables in provisioning script to handle spaces

### DIFF
--- a/scripts/provisioning.sh
+++ b/scripts/provisioning.sh
@@ -9,10 +9,10 @@
 
 # Provision EKS tenant.
 aws codebuild start-build --project-name TenantOnboardingProject --environment-variables-override \
-name=TENANT_ID,value=$tenantId,type=PLAINTEXT \
-name=PLAN,value=$tier,type=PLAINTEXT \
-name=COMPANY_NAME,value=$tenantName,type=PLAINTEXT \
-name=ADMIN_EMAIL,value=$email,type=PLAINTEXT
+name=TENANT_ID,value="$tenantId",type=PLAINTEXT \
+name=PLAN,value="$tier",type=PLAINTEXT \
+name=COMPANY_NAME,value="$tenantName",type=PLAINTEXT \
+name=ADMIN_EMAIL,value="$email",type=PLAINTEXT
 
 STACK_NAME="TenantStack-$tenantId"
 


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

When tenant names contain spaces (e.g., "Brian Cain"), the provisioning script fails with a parameter parsing error because the AWS CLI interprets the space as a delimiter in the comma-separated format.

Error observed:

```
Error parsing parameter '--environment-variables-override': Expected: '=', received: ',' for input:
Cain,type=PLAINTEXT
```

This causes the TenantOnboardingProject CodeBuild to never start, leaving the tenant in a broken state with no CloudFormation stack or resources.

Solution:
Added quotes around all variable values in the aws codebuild start-build command to properly escape spaces and special characters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
